### PR TITLE
Working tests

### DIFF
--- a/stylelint-plugins/kaliber.js
+++ b/stylelint-plugins/kaliber.js
@@ -120,7 +120,7 @@ function createPlugin({
       if (!stylelint.utils.validateOptions(result, ruleName, check)) return
 
       const reported = {}
-      const importFrom = findCssGlobalFiles(originalRoot.source.input.file)
+      const importFrom = findCssGlobalFiles(originalRoot?.source?.input?.file)
 
       const modifiedRoot = originalRoot.clone()
       if (resolvedModuleValues) {

--- a/stylelint-plugins/machinery/findCssGlobalFiles.js
+++ b/stylelint-plugins/machinery/findCssGlobalFiles.js
@@ -7,6 +7,8 @@ module.exports = {
 }
 
 function findCssGlobalFiles(from) {
+  if (!from) return []
+
   const propertiesDirectory = path.resolve(findRootDirectory(from), './src/cssGlobal')
   return fs.existsSync(propertiesDirectory)
     ? fs.readdirSync(propertiesDirectory)


### PR DESCRIPTION
Fixes the error `TypeError [ERR_INVALID_ARG_TYPE]: The "paths[0]" argument must be of type string. Received undefined` when running `yarn test`