### PR TITLE
allow ch units

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -18,21 +18,21 @@
     "kaliber/selector-policy": true,
 
     "at-rule-blacklist": [
-      'apply',
-      'annotation',
-      'character-variant',
-      'charset',
-      'counter-style',
-      'document',
-      'font-feature-values',
-      'namespace',
-      'nest',
-      'ornaments',
-      'page',
-      'styleset',
-      'stylistic',
-      'swash',
-      'viewport',
+      "apply",
+      "annotation",
+      "character-variant",
+      "charset",
+      "counter-style",
+      "document",
+      "font-feature-values",
+      "namespace",
+      "nest",
+      "ornaments",
+      "page",
+      "styleset",
+      "stylistic",
+      "swash",
+      "viewport"
     ],
     "at-rule-empty-line-before": [
       "always", {
@@ -152,7 +152,7 @@
     "property-no-unknown": [
       true,
       {
-        ignoreSelectors: ":export"
+        "ignoreSelectors": ":export"
       }
     ],
     "rule-empty-line-before": [
@@ -190,7 +190,7 @@
     "selector-type-no-unknown": [
       true,
       {
-        ignore: ["custom-elements"]
+        "ignore": ["custom-elements"]
       }
     ],
     "string-no-newline": true,
@@ -216,7 +216,8 @@
       "svh",
       "svw",
       "lvh",
-      "lvw"
+      "lvw",
+      "ch"
     ],
     "value-list-comma-newline-after": "always-multi-line",
     "value-list-comma-space-after": "always-single-line",

--- a/stylelint-plugins/rules/layout-related-properties/index.js
+++ b/stylelint-plugins/rules/layout-related-properties/index.js
@@ -6,7 +6,7 @@ const {
 } = require('../../machinery/ast')
 const { flexChildProps, gridChildProps, flexOrGridChildProps } = require('../../machinery/css')
 
-const intrinsicUnits = ['px', 'em', 'rem', 'vw', 'vh', 'dvw', 'dvh', 'svh', 'svw', 'lvh', 'lvw']
+const intrinsicUnits = ['px', 'em', 'rem', 'vw', 'vh', 'dvw', 'dvh', 'svh', 'svw', 'lvh', 'lvw', 'ch']
 const intrinsicProps = ['width', 'height', 'max-width', 'min-width', 'max-height', 'min-height']
 
 const allowedInRootAndChild = [


### PR DESCRIPTION
Komt op 107 plekken voor: https://github.com/search?q=org%3AKaliber+%2F%28%5B0-9%5D%2B%29ch%2F+language%3ACSS+&type=code

Lijkt me dan goed om dit toe te gaan staan.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the "ch" (character width) unit in layout-related property validation so styles using this unit no longer trigger validation errors.

* **Chores**
  * Standardized configuration formatting and updated rule options; unit whitelist and selector lists were adjusted to recognize "ch".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->