### PR TITLE
add new units and update ignore-list

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -227,7 +227,9 @@
       "cqi",
       "cqb",
       "cqmin",
-      "cqmax"
+      "cqmax",
+      "lh",
+      "rlh"
     ],
     "value-list-comma-newline-after": "always-multi-line",
     "value-list-comma-space-after": "always-single-line",

--- a/.stylelintrc
+++ b/.stylelintrc
@@ -152,7 +152,11 @@
     "property-no-unknown": [
       true,
       {
-        "ignoreSelectors": ":export"
+        "ignoreSelectors": ":export",
+        "ignoreProperties": [
+          "container-type",
+          "interpolate-size"
+        ]
       }
     ],
     "rule-empty-line-before": [
@@ -217,7 +221,13 @@
       "svw",
       "lvh",
       "lvw",
-      "ch"
+      "ch",
+      "cqw",
+      "cqh",
+      "cqi",
+      "cqb",
+      "cqmin",
+      "cqmax"
     ],
     "value-list-comma-newline-after": "always-multi-line",
     "value-list-comma-space-after": "always-single-line",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated stylesheet linting rules to recognize additional CSS units (container-query units: cqw, cqh, cqi, cqb, cqmin, cqmax; and line-height-related units: lh, rlh) and to allow modern CSS properties such as container-type and interpolate-size, preventing false-positive linting errors and enabling use of newer CSS features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->