### PR TITLE
Experimental rules

### DIFF
--- a/stylelint-plugins/kaliber.js
+++ b/stylelint-plugins/kaliber.js
@@ -10,6 +10,9 @@ import rootPolicy from './rules/root-policy/index.js'
 import atRuleRestrictions from './rules/at-rule-restrictions/index.js'
 import indexRule from './rules/index/index.js'
 import reset from './rules/reset/index.js'
+import noHardcodedColors from './rules/no-hardcoded-colors/index.js'
+import colorVariableLayering from './rules/color-variable-layering/index.js'
+import mediaQueryConvention from './rules/media-query-convention/index.js'
 
 /*
   Motivation
@@ -33,6 +36,9 @@ const rules = toStyleLintPlugins(
   atRuleRestrictions,
   indexRule,
   reset,
+  noHardcodedColors,
+  colorVariableLayering,
+  mediaQueryConvention,
 )
 export default rules
 
@@ -132,7 +138,7 @@ function createPlugin({
         })
 
       function callPlugin(modifiedRoot) {
-        plugin({ modifiedRoot, originalRoot, report, context })
+        plugin({ modifiedRoot, originalRoot, report, context, options: secondaryOptionObject })
       }
 
       function report(node, message, index) {

--- a/stylelint-plugins/machinery/breakpoints.js
+++ b/stylelint-plugins/machinery/breakpoints.js
@@ -1,0 +1,97 @@
+import { readCssGlobalFile } from './cssGlobal.js'
+
+const breakpointCache = new Map()
+
+/**
+ * Reads and parses breakpoints from the cssGlobal directory.
+ * Tries media.js first, then media.css. Results are cached per path.
+ *
+ * @param {string} cssGlobalPath
+ * @returns {Set<string> | null}
+ */
+export function getBreakpoints(cssGlobalPath) {
+  if (breakpointCache.has('__test__')) return breakpointCache.get('__test__')
+  if (breakpointCache.has(cssGlobalPath)) return breakpointCache.get(cssGlobalPath)
+
+  const jsContent = readCssGlobalFile(cssGlobalPath, 'media.js')
+  if (jsContent) {
+    const breakpoints = parseMediaJs(jsContent)
+    breakpointCache.set(cssGlobalPath, breakpoints)
+    return breakpoints
+  }
+
+  const cssContent = readCssGlobalFile(cssGlobalPath, 'media.css')
+  if (cssContent) {
+    const breakpoints = parseMediaCss(cssContent)
+    breakpointCache.set(cssGlobalPath, breakpoints)
+    return breakpoints
+  }
+
+  breakpointCache.set(cssGlobalPath, null)
+  return null
+}
+
+/**
+ * Seeds the breakpoint cache for testing.
+ *
+ * @param {string[]} values - Array of breakpoint values (e.g., ['48rem', '80rem'])
+ */
+export function seedBreakpointCache(values) {
+  breakpointCache.set('__test__', new Set(values))
+}
+
+/**
+ * Parses media.js content to extract breakpoint values.
+ * Handles two formats found across Kaliber projects:
+ *
+ * 1. Full query strings: `viewportMd: 'screen and (min-width: 768px)'`
+ *    → extracts "768px"
+ *
+ * 2. Raw values: `breakpointMd: '768px'` or `breakpointMd: '48em'`
+ *    → extracts "768px" / "48em"
+ *
+ * Non-width entries like `touch: '(pointer: coarse)'` are ignored.
+ *
+ * @param {string} content
+ * @returns {Set<string>}
+ */
+function parseMediaJs(content) {
+  const breakpoints = new Set()
+  const entryPattern = /(\w+)\s*:\s*['"]([^'"]+)['"]/g
+  let match
+
+  while ((match = entryPattern.exec(content)) !== null) {
+    const value = match[2]
+
+    const widthMatch = value.match(/(?:min-width|max-width)\s*:\s*([^)]+)/)
+    if (widthMatch) {
+      breakpoints.add(widthMatch[1].trim())
+      continue
+    }
+
+    if (/^\d+(\.\d+)?(px|em|rem)$/.test(value.trim())) {
+      breakpoints.add(value.trim())
+    }
+  }
+
+  return breakpoints
+}
+
+/**
+ * Parses media.css content to extract breakpoint values.
+ * Format: `@custom-media --viewport-md screen and (min-width: 768px);`
+ *
+ * @param {string} content
+ * @returns {Set<string>}
+ */
+function parseMediaCss(content) {
+  const breakpoints = new Set()
+  const pattern = /(?:min-width|max-width)\s*:\s*([^)]+)/g
+  let match
+
+  while ((match = pattern.exec(content)) !== null) {
+    breakpoints.add(match[1].trim())
+  }
+
+  return breakpoints
+}

--- a/stylelint-plugins/machinery/cssGlobal.js
+++ b/stylelint-plugins/machinery/cssGlobal.js
@@ -1,0 +1,69 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+/**
+ * Shared cssGlobal reader — caches reads per cssGlobal path.
+ *
+ * Rules that need data from cssGlobal/ (style-contexts, media, motion, etc.)
+ * should use this module instead of reading files directly.
+ *
+ * Configure via the `cssGlobal` option in .stylelintrc:
+ *
+ *   "kaliber/color-variable-layering": [true, { "cssGlobal": "src/cssGlobal" }]
+ *
+ * @example
+ *   import { readCssGlobalFile } from '../../machinery/cssGlobal.js'
+ *   const content = readCssGlobalFile(options?.cssGlobal, 'style-context.css')
+ */
+
+const fileCache = new Map()
+
+/**
+ * Reads a file from the configured cssGlobal directory. Results are cached
+ * per resolved path so files are read at most once per lint session.
+ *
+ * @param {string} cssGlobalPath - Relative path to the cssGlobal directory (from cwd)
+ * @param {string} filename - File to read within cssGlobal (e.g. 'style-context.css')
+ * @returns {string | null} - File contents or null if not found
+ */
+export function readCssGlobalFile(cssGlobalPath, filename) {
+  if (!cssGlobalPath) return null
+
+  const fullPath = resolve(process.cwd(), cssGlobalPath, filename)
+  if (fileCache.has(fullPath)) return fileCache.get(fullPath)
+
+  try {
+    const content = readFileSync(fullPath, 'utf-8')
+    fileCache.set(fullPath, content)
+    return content
+  } catch {
+    fileCache.set(fullPath, null)
+    return null
+  }
+}
+
+/**
+ * Checks if a file path is inside the configured cssGlobal directory.
+ * Falls back to a heuristic check if no cssGlobal path is configured.
+ *
+ * @param {string} filePath - The file being linted
+ * @param {string} [cssGlobalPath] - Configured cssGlobal path
+ * @returns {boolean}
+ */
+export function isInsideCssGlobal(filePath, cssGlobalPath) {
+  if (cssGlobalPath) {
+    const resolvedCssGlobal = resolve(process.cwd(), cssGlobalPath)
+    return filePath.startsWith(resolvedCssGlobal)
+  }
+  return filePath.includes('/cssGlobal/')
+}
+
+/**
+ * Seed a file into the cache for testing.
+ *
+ * @param {string} key - Cache key (use the filename, e.g. 'style-context.css')
+ * @param {string | null} content - File contents
+ */
+export function seedFileCache(key, content) {
+  fileCache.set(key, content)
+}

--- a/stylelint-plugins/machinery/test.js
+++ b/stylelint-plugins/machinery/test.js
@@ -35,7 +35,7 @@ async function runTest(ruleName, test) {
     config: {
       plugins: [fileURLToPath(new URL('../kaliber.js', import.meta.url))],
       rules: {
-        [`kaliber/${ruleName}`]: [true]
+        [`kaliber/${ruleName}`]: test.config ? [true, test.config] : [true]
       }
     },
     fix: Boolean(test.output)

--- a/stylelint-plugins/rules/color-variable-layering/index.js
+++ b/stylelint-plugins/rules/color-variable-layering/index.js
@@ -8,12 +8,6 @@ import docsUrl from '../../machinery/docsUrl.js'
  */
 const varReferencePattern = /var\(\s*(--[a-zA-Z0-9-]+)/g
 
-/**
- * Filenames to try when looking for context tokens inside cssGlobal/.
- * Some projects use singular, others plural.
- */
-const contextFileNames = ['style-context.css', 'style-contexts.css']
-
 export const messages = {
   'use context token': (token, suggestion) =>
     `Unexpected non-context color token "${token}"\n` +
@@ -39,7 +33,7 @@ function extractContextTokens(cssContent) {
   return tokens
 }
 
-/** Parsed token cache — keyed by cssGlobal path */
+/** Parsed token cache — keyed by combined cssGlobal path and filenames */
 const tokenCache = new Map()
 
 /**
@@ -54,24 +48,73 @@ export function seedTokenCache(tokens) {
 
 /**
  * Reads context tokens from the configured cssGlobal directory.
- * Tries both `style-context.css` and `style-contexts.css`.
+ * Tries the configured styleContextFiles.
  *
  * @param {string} cssGlobalPath
+ * @param {string[]} styleContextFiles
  * @returns {Set<string> | null}
  */
-function getContextTokens(cssGlobalPath) {
-  if (tokenCache.has(cssGlobalPath)) return tokenCache.get(cssGlobalPath)
+function getContextTokens(cssGlobalPath, styleContextFiles) {
+  const cacheKey = `${cssGlobalPath}::${styleContextFiles.join(',')}`
+  if (tokenCache.has(cacheKey)) return tokenCache.get(cacheKey)
 
-  for (const filename of contextFileNames) {
+  for (const filename of styleContextFiles) {
     const content = readCssGlobalFile(cssGlobalPath, filename)
     if (content) {
       const tokens = extractContextTokens(content)
-      tokenCache.set(cssGlobalPath, tokens)
+      tokenCache.set(cacheKey, tokens)
       return tokens
     }
   }
 
-  tokenCache.set(cssGlobalPath, null)
+  tokenCache.set(cacheKey, null)
+  return null
+}
+
+const defaultIgnorePatterns = [
+  /\/cssGlobal\//,
+  /style-context/,
+  /colorScheme.*\.css/
+]
+
+function isInfraFile(root, ignoreFiles = []) {
+  return matchesFile(root, filename => {
+    if (defaultIgnorePatterns.some(regex => regex.test(filename))) return true
+    return ignoreFiles.some(pattern => {
+      try {
+        if (pattern.startsWith('/') && pattern.endsWith('/')) {
+          return new RegExp(pattern.slice(1, -1)).test(filename)
+        }
+        return filename.includes(pattern)
+      } catch {
+        return false
+      }
+    })
+  })
+}
+
+function isColorToken(tokenName) {
+  return tokenName.startsWith('--color')
+}
+
+/**
+ * Suggest a likely context token replacement for common semantic/palette tokens.
+ */
+function suggestContextToken(tokenName, customSuggestions = {}) {
+  if (customSuggestions && typeof customSuggestions === 'object') {
+    if (customSuggestions[tokenName]) return customSuggestions[tokenName]
+    for (const [pattern, suggestion] of Object.entries(customSuggestions)) {
+      try {
+        if (new RegExp(pattern).test(tokenName)) return suggestion
+      } catch {
+        // ignore invalid regex patterns
+      }
+    }
+  }
+
+  if (/--color-primary/.test(tokenName)) return '--accent-color'
+  if (/--color-surface/.test(tokenName)) return '--background-color'
+  if (/--color-text/.test(tokenName)) return '--color'
   return null
 }
 
@@ -86,28 +129,32 @@ export default defineRule({
   messages,
   create() {
     return ({ originalRoot, report, options }) => {
+      const cssGlobal = options?.cssGlobal
+      const styleContextFiles = options?.styleContextFiles || ['style-context.css', 'style-contexts.css']
+      const ignoreFiles = options?.ignoreFiles || []
+      const suggestions = options?.suggestions || {}
+
       // Skip infrastructure files — they can use any layer
-      if (isInfraFile(originalRoot)) return
+      if (isInfraFile(originalRoot, ignoreFiles)) return
 
       // For test files (virtual paths), use the seeded test tokens
       if (tokenCache.has('__test__')) {
-        checkDeclarations(originalRoot, tokenCache.get('__test__'), report)
+        checkDeclarations(originalRoot, tokenCache.get('__test__'), report, suggestions)
         return
       }
 
       // Require cssGlobal option — the rule is a no-op without it
-      const cssGlobal = options?.cssGlobal
       if (!cssGlobal) return
 
-      const contextTokens = getContextTokens(cssGlobal)
+      const contextTokens = getContextTokens(cssGlobal, styleContextFiles)
       if (!contextTokens || contextTokens.size === 0) return
 
-      checkDeclarations(originalRoot, contextTokens, report)
+      checkDeclarations(originalRoot, contextTokens, report, suggestions)
     }
   }
 })
 
-function checkDeclarations(root, contextTokens, report) {
+function checkDeclarations(root, contextTokens, report, customSuggestions) {
   root.walkDecls(decl => {
     const { value, prop } = decl
 
@@ -123,31 +170,9 @@ function checkDeclarations(root, contextTokens, report) {
 
       // If this isn't a known context token, flag it
       if (!contextTokens.has(tokenName)) {
-        const suggestion = suggestContextToken(tokenName)
+        const suggestion = suggestContextToken(tokenName, customSuggestions)
         report(decl, messages['use context token'](tokenName, suggestion))
       }
     }
   })
-}
-
-function isInfraFile(root) {
-  return matchesFile(root, filename =>
-    filename.includes('/cssGlobal/') ||
-    filename.includes('style-contexts') ||
-    /colorScheme.*\.css/.test(filename)
-  )
-}
-
-function isColorToken(tokenName) {
-  return tokenName.startsWith('--color')
-}
-
-/**
- * Suggest a likely context token replacement for common semantic/palette tokens.
- */
-function suggestContextToken(tokenName) {
-  if (/--color-primary/.test(tokenName)) return '--accent-color'
-  if (/--color-surface/.test(tokenName)) return '--background-color'
-  if (/--color-text/.test(tokenName)) return '--color'
-  return null
 }

--- a/stylelint-plugins/rules/color-variable-layering/index.js
+++ b/stylelint-plugins/rules/color-variable-layering/index.js
@@ -1,0 +1,153 @@
+import { matchesFile } from '../../machinery/filename.js'
+import { readCssGlobalFile } from '../../machinery/cssGlobal.js'
+import defineRule from '../../machinery/defineRule.js'
+import docsUrl from '../../machinery/docsUrl.js'
+
+/**
+ * Extracts all var(--*) references from a CSS value string.
+ */
+const varReferencePattern = /var\(\s*(--[a-zA-Z0-9-]+)/g
+
+/**
+ * Filenames to try when looking for context tokens inside cssGlobal/.
+ * Some projects use singular, others plural.
+ */
+const contextFileNames = ['style-context.css', 'style-contexts.css']
+
+export const messages = {
+  'use context token': (token, suggestion) =>
+    `Unexpected non-context color token "${token}"\n` +
+    `components should use context-layer tokens from style-contexts.css` +
+    (suggestion ? ` (e.g. var(${suggestion}))` : '') +
+    `\nmove this to cssGlobal/ or style-contexts.css, or use a context token instead`
+}
+
+/**
+ * Extracts custom property names from style-contexts.css content.
+ * Only matches lines that look like `--token-name: ...;` declarations.
+ *
+ * @param {string} cssContent
+ * @returns {Set<string>}
+ */
+function extractContextTokens(cssContent) {
+  const tokens = new Set()
+  const declPattern = /^\s*(--[a-zA-Z0-9-]+)\s*:/gm
+  let match
+  while ((match = declPattern.exec(cssContent)) !== null) {
+    tokens.add(match[1])
+  }
+  return tokens
+}
+
+/** Parsed token cache — keyed by cssGlobal path */
+const tokenCache = new Map()
+
+/**
+ * Seeds the token cache for testing — allows tests to provide context tokens
+ * without needing a real style-contexts.css file on disk.
+ *
+ * @param {string[]} tokens - Array of context token names
+ */
+export function seedTokenCache(tokens) {
+  tokenCache.set('__test__', new Set(tokens))
+}
+
+/**
+ * Reads context tokens from the configured cssGlobal directory.
+ * Tries both `style-context.css` and `style-contexts.css`.
+ *
+ * @param {string} cssGlobalPath
+ * @returns {Set<string> | null}
+ */
+function getContextTokens(cssGlobalPath) {
+  if (tokenCache.has(cssGlobalPath)) return tokenCache.get(cssGlobalPath)
+
+  for (const filename of contextFileNames) {
+    const content = readCssGlobalFile(cssGlobalPath, filename)
+    if (content) {
+      const tokens = extractContextTokens(content)
+      tokenCache.set(cssGlobalPath, tokens)
+      return tokens
+    }
+  }
+
+  tokenCache.set(cssGlobalPath, null)
+  return null
+}
+
+export default defineRule({
+  ruleName: 'color-variable-layering',
+  meta: {
+    description: 'Enforce that component CSS only uses context-layer color tokens (not palette or semantic tokens)',
+    url: docsUrl(import.meta.dirname),
+  },
+  ruleInteraction: null,
+  cssRequirements: null,
+  messages,
+  create() {
+    return ({ originalRoot, report, options }) => {
+      // Skip infrastructure files — they can use any layer
+      if (isInfraFile(originalRoot)) return
+
+      // For test files (virtual paths), use the seeded test tokens
+      if (tokenCache.has('__test__')) {
+        checkDeclarations(originalRoot, tokenCache.get('__test__'), report)
+        return
+      }
+
+      // Require cssGlobal option — the rule is a no-op without it
+      const cssGlobal = options?.cssGlobal
+      if (!cssGlobal) return
+
+      const contextTokens = getContextTokens(cssGlobal)
+      if (!contextTokens || contextTokens.size === 0) return
+
+      checkDeclarations(originalRoot, contextTokens, report)
+    }
+  }
+})
+
+function checkDeclarations(root, contextTokens, report) {
+  root.walkDecls(decl => {
+    const { value, prop } = decl
+
+    // Skip custom property definitions — they're creating tokens, not consuming them
+    if (prop.startsWith('--')) return
+
+    const matches = value.matchAll(varReferencePattern)
+    for (const match of matches) {
+      const tokenName = match[1]
+
+      // Only check color-related tokens (starting with --color)
+      if (!isColorToken(tokenName)) continue
+
+      // If this isn't a known context token, flag it
+      if (!contextTokens.has(tokenName)) {
+        const suggestion = suggestContextToken(tokenName)
+        report(decl, messages['use context token'](tokenName, suggestion))
+      }
+    }
+  })
+}
+
+function isInfraFile(root) {
+  return matchesFile(root, filename =>
+    filename.includes('/cssGlobal/') ||
+    filename.includes('style-contexts') ||
+    /colorScheme.*\.css/.test(filename)
+  )
+}
+
+function isColorToken(tokenName) {
+  return tokenName.startsWith('--color')
+}
+
+/**
+ * Suggest a likely context token replacement for common semantic/palette tokens.
+ */
+function suggestContextToken(tokenName) {
+  if (/--color-primary/.test(tokenName)) return '--accent-color'
+  if (/--color-surface/.test(tokenName)) return '--background-color'
+  if (/--color-text/.test(tokenName)) return '--color'
+  return null
+}

--- a/stylelint-plugins/rules/color-variable-layering/readme.md
+++ b/stylelint-plugins/rules/color-variable-layering/readme.md
@@ -1,0 +1,87 @@
+# color-variable-layering
+
+Enforce that component CSS only uses context-layer color tokens (not palette or semantic tokens).
+
+## Rationale
+
+Kaliber projects use a three-layer color architecture:
+
+```
+Layer 1 (Palette)  : --color-teal, --color-blue-500, --color-granite
+                     ↕ defined in color.css / themes/*.css
+
+Layer 2 (Semantic) : --color-primary, --color-surface, --color-text
+                     ↕ defined in themes/*.css, mapped from palette
+
+Layer 3 (Context)  : --color, --background-color, --accent-color
+                     ↕ defined in style-contexts.css, mapped from semantic
+                     ↕ THIS is what components should use
+```
+
+Each layer varies at a different scope:
+- **Palette** is fixed per brand (rabobank vs landal)
+- **Semantic** is fixed per theme (`[data-theme-context]`) — same across all style contexts
+- **Context** varies per `[data-style-context]` — adapts to light/dark/blue/etc.
+
+Using `var(--color-primary)` in a component **won't adapt** when the component sits inside `[data-style-context='dark']`. In the dark context, `--accent-color` maps to `--color-primary-light` (not `--color-primary`).
+
+## Configuration
+
+This rule requires a `cssGlobal` option pointing to your cssGlobal directory:
+
+```json
+{
+  "kaliber/color-variable-layering": [true, {
+    "cssGlobal": "src/cssGlobal"
+  }]
+}
+```
+
+The path is resolved relative to the working directory where stylelint runs (typically the project root). The rule automatically looks for `style-context.css` or `style-contexts.css` inside the configured directory.
+
+Without `cssGlobal`, the rule is a no-op.
+
+## How it works
+
+The rule **reads the configured `contextFile`** at lint-time to discover which custom properties are context-layer tokens (the left-hand side of declarations inside `[data-style-context]` blocks). Any `var(--color-*)` reference in component CSS that isn't in the discovered context token list gets flagged.
+
+## What this rule checks
+
+In **component CSS files**, this rule flags:
+- Palette tokens: `var(--color-blue-500)`, `var(--color-gray-200)`, `var(--color-teal)`
+- Semantic tokens: `var(--color-primary)`, `var(--color-surface)`, `var(--color-text)`
+
+## What this rule allows
+
+- **Context tokens**: `var(--color)`, `var(--accent-color)`, `var(--background-color)`, etc.
+- **Non-color variables**: `var(--size-16)`, `var(--font-size-md)`, etc.
+- **Custom property definitions**: `--my-gradient: var(--color-primary)` — defining tokens is allowed
+- **Infrastructure files**: `cssGlobal/`, `style-contexts.css`, `colorScheme*.css`
+
+## Examples
+
+### ✅ Valid
+
+```css
+/* features/buildingBlocks/Button.css */
+.component { color: var(--color); background-color: var(--accent-color); }
+```
+
+```css
+/* Custom property definition — allowed */
+.component { --card-overlay: var(--color-primary); }
+```
+
+### ❌ Invalid
+
+```css
+/* features/buildingBlocks/ApplyBanner.css — semantic token leak */
+.component { background-color: var(--color-primary); }
+/* should be: var(--accent-color) or var(--button-background-color) */
+```
+
+```css
+/* pages/Skills.css — palette token leak */
+.component { background-color: var(--color-gray-200); }
+/* should be: var(--shade-color) */
+```

--- a/stylelint-plugins/rules/color-variable-layering/readme.md
+++ b/stylelint-plugins/rules/color-variable-layering/readme.md
@@ -27,17 +27,28 @@ Using `var(--color-primary)` in a component **won't adapt** when the component s
 
 ## Configuration
 
-This rule requires a `cssGlobal` option pointing to your cssGlobal directory:
+This rule accepts an options object with the following properties:
+
+- `cssGlobal` (required): Relative path pointing to your `cssGlobal` directory.
+- `styleContextFiles` (optional): Array of filenames within `cssGlobal` to scan for context tokens. Defaults to `['style-context.css', 'style-contexts.css']`.
+- `ignoreFiles` (optional): Array of patterns (substrings or regex strings like `"/my-custom-theme/"`) specifying files to skip validation on.
+- `suggestions` (optional): Dictionary mapping semantic or palette tokens (keys) to recommended context replacements (values). Keys can be exact match strings or regex pattern strings.
+
+Example:
 
 ```json
 {
   "kaliber/color-variable-layering": [true, {
-    "cssGlobal": "src/cssGlobal"
+    "cssGlobal": "src/cssGlobal",
+    "styleContextFiles": ["style-contexts.css"],
+    "ignoreFiles": ["/custom-infra/", "legacyTheme"],
+    "suggestions": {
+      "--color-primary-brand": "--accent-color",
+      "^--color-gray-\\d+$": "--shade-color"
+    }
   }]
 }
 ```
-
-The path is resolved relative to the working directory where stylelint runs (typically the project root). The rule automatically looks for `style-context.css` or `style-contexts.css` inside the configured directory.
 
 Without `cssGlobal`, the rule is a no-op.
 

--- a/stylelint-plugins/rules/color-variable-layering/test.js
+++ b/stylelint-plugins/rules/color-variable-layering/test.js
@@ -1,0 +1,107 @@
+import { messages, seedTokenCache } from './index.js'
+import { test } from '../../machinery/test.js'
+
+// Seed the token cache with typical context tokens (as would be found in style-contexts.css)
+seedTokenCache([
+  '--background-color',
+  '--color',
+  '--accent-color',
+  '--accent-color--60',
+  '--accent-color--40',
+  '--shade-color',
+  '--contrast-color',
+  '--muted-color',
+  '--error-color',
+  '--input-border-color',
+  '--focus-border-color',
+  '--button-background-color',
+  '--button-color',
+  '--primary-text-color',
+  '--secondary-text-color',
+  '--color-error',
+  '--hairline-color',
+  '--link-color',
+])
+
+test('color-variable-layering', {
+  'color-variable-layering': {
+    valid: [
+      {
+        title: 'allow context tokens in component files',
+        filename: 'features/buildingBlocks/Button.css',
+        code: '.component { color: var(--color); background-color: var(--accent-color); }'
+      },
+      {
+        title: 'allow non-color custom properties in component files',
+        filename: 'features/buildingBlocks/Card.css',
+        code: '.component { padding: var(--size-16); font-size: var(--font-size-md); }'
+      },
+      {
+        title: 'allow palette tokens in cssGlobal files',
+        filename: 'cssGlobal/color.css',
+        code: ':root { --color-blue-500: #0058ff; }'
+      },
+      {
+        title: 'allow semantic tokens in style-contexts files',
+        filename: 'cssGlobal/style-contexts.css',
+        code: '.component { --accent-color: var(--color-primary); }'
+      },
+      {
+        title: 'allow palette tokens in theme files',
+        filename: 'cssGlobal/themes/landal.css',
+        code: ':root { --color-primary: var(--color-teal); }'
+      },
+      {
+        title: 'allow custom property definitions using palette tokens',
+        filename: 'features/buildingBlocks/Tile.css',
+        code: '.component { --my-token: var(--color-blue-500); }'
+      },
+      {
+        title: 'allow context tokens with error naming pattern',
+        filename: 'features/buildingBlocks/Form.css',
+        code: '.component { border-color: var(--color-error); color: var(--error-color); }'
+      },
+    ],
+    invalid: [
+      {
+        title: 'disallow palette tokens (--color-blue-500) in component files',
+        filename: 'features/buildingBlocks/Card.css',
+        code: '.component { color: var(--color-blue-500); }',
+        warnings: [messages['use context token']('--color-blue-500', null)]
+      },
+      {
+        title: 'disallow semantic tokens (--color-primary) in component files',
+        filename: 'features/buildingBlocks/ApplyBanner.css',
+        code: '.component { background-color: var(--color-primary); }',
+        warnings: [messages['use context token']('--color-primary', '--accent-color')]
+      },
+      {
+        title: 'disallow semantic tokens (--color-surface) in component files',
+        filename: 'features/buildingBlocks/Section.css',
+        code: '.component { background-color: var(--color-surface); }',
+        warnings: [messages['use context token']('--color-surface', '--background-color')]
+      },
+      {
+        title: 'disallow semantic tokens (--color-text) in component files',
+        filename: 'features/pageOnly/Footer.css',
+        code: '.component { color: var(--color-text); }',
+        warnings: [messages['use context token']('--color-text', '--color')]
+      },
+      {
+        title: 'disallow palette tokens (--color-gray-200) in component files',
+        filename: 'pages/Skills.css',
+        code: '.component { background-color: var(--color-gray-200); }',
+        warnings: [messages['use context token']('--color-gray-200', null)]
+      },
+      {
+        title: 'disallow multiple violations in one declaration',
+        filename: 'features/buildingBlocks/Hero.css',
+        code: '.component { background: linear-gradient(var(--color-blue-500), var(--color-blue-700)); }',
+        warnings: [
+          messages['use context token']('--color-blue-500', null),
+          messages['use context token']('--color-blue-700', null),
+        ]
+      },
+    ],
+  },
+})

--- a/stylelint-plugins/rules/color-variable-layering/test.js
+++ b/stylelint-plugins/rules/color-variable-layering/test.js
@@ -61,6 +61,12 @@ test('color-variable-layering', {
         filename: 'features/buildingBlocks/Form.css',
         code: '.component { border-color: var(--color-error); color: var(--error-color); }'
       },
+      {
+        title: 'allow custom infra file paths via ignoreFiles option',
+        filename: 'features/myCustomInfra/helpers.css',
+        config: { ignoreFiles: ['myCustomInfra'] },
+        code: '.component { color: var(--color-blue-500); }'
+      },
     ],
     invalid: [
       {
@@ -101,6 +107,13 @@ test('color-variable-layering', {
           messages['use context token']('--color-blue-500', null),
           messages['use context token']('--color-blue-700', null),
         ]
+      },
+      {
+        title: 'provide custom suggestions via suggestions option',
+        filename: 'features/buildingBlocks/Hero.css',
+        config: { suggestions: { '--color-primary-custom': '--accent-color-custom' } },
+        code: '.component { color: var(--color-primary-custom); }',
+        warnings: [messages['use context token']('--color-primary-custom', '--accent-color-custom')]
       },
     ],
   },

--- a/stylelint-plugins/rules/media-query-convention/index.js
+++ b/stylelint-plugins/rules/media-query-convention/index.js
@@ -1,0 +1,84 @@
+import { getBreakpoints, seedBreakpointCache as _seedBreakpointCache } from '../../machinery/breakpoints.js'
+import defineRule from '../../machinery/defineRule.js'
+import docsUrl from '../../machinery/docsUrl.js'
+
+export const seedBreakpointCache = _seedBreakpointCache
+
+export const messages = {
+  'prefer min-width': value =>
+    `Unexpected "max-width" media query\n` +
+    `use "min-width" for mobile-first design, or "not screen and (min-width: ...)" for the inverse\n` +
+    `found: @media ${value}`,
+  'breakpoint not recognized': (value, available) =>
+    `Unrecognized breakpoint value "${value}"\n` +
+    `use a breakpoint defined in cssGlobal/media: ${available}`,
+}
+
+export default defineRule({
+  ruleName: 'media-query-convention',
+  meta: {
+    description: 'Enforce consistent @media query patterns: prefer min-width, use defined breakpoints',
+    url: docsUrl(import.meta.dirname),
+  },
+  ruleInteraction: null,
+  cssRequirements: null,
+  messages,
+  create() {
+    return ({ originalRoot, report, options }) => {
+      const breakpoints = getBreakpoints(options?.cssGlobal)
+
+      originalRoot.walkAtRules('media', atRule => {
+        const params = atRule.params
+
+        if (isNonWidthQuery(params)) return
+
+        const widthMatch = params.match(widthPattern)
+        if (!widthMatch) return
+
+        const [, type, value] = widthMatch
+        const trimmedValue = value.trim()
+
+        // Flag max-width usage
+        if (type === 'max-width') {
+          const widthMatches = params.match(/max-width/g)
+          if (widthMatches && widthMatches.length === 1 && isComplexQuery(params)) return
+
+          report(atRule, messages['prefer min-width'](params))
+          return
+        }
+
+        // Validate breakpoint value against defined breakpoints
+        if (breakpoints && breakpoints.size > 0 && !breakpoints.has(trimmedValue)) {
+          const available = [...breakpoints].join(', ')
+          report(atRule, messages['breakpoint not recognized'](trimmedValue, available))
+        }
+      })
+    }
+  }
+})
+
+/** Extracts a min-width or max-width value from a media query params string. */
+const widthPattern = /\(\s*(min-width|max-width)\s*:\s*([^)]+)\)/
+
+/**
+ * Non-width media features that are always allowed regardless of breakpoint convention.
+ * These don't relate to viewport sizing and should pass through unchecked.
+ */
+const nonWidthFeatures = [
+  'prefers-reduced-motion',
+  'prefers-color-scheme',
+  'prefers-contrast',
+  'hover',
+  'pointer',
+  'orientation',
+  'display-mode',
+  'forced-colors',
+]
+
+function isNonWidthQuery(params) {
+  return nonWidthFeatures.some(feature => params.includes(feature))
+}
+
+function isComplexQuery(params) {
+  return params.includes('orientation') || params.includes('max-height') || params.includes('aspect-ratio')
+}

--- a/stylelint-plugins/rules/media-query-convention/readme.md
+++ b/stylelint-plugins/rules/media-query-convention/readme.md
@@ -1,0 +1,79 @@
+# media-query-convention
+
+Enforce consistent `@media` query patterns across the codebase.
+
+## Rationale
+
+All Kaliber projects follow a **mobile-first** approach using `min-width` media queries. Using `max-width` queries creates inconsistency and makes responsive behavior harder to reason about.
+
+Additionally, breakpoint values should come from the project's `cssGlobal/media.js` or `media.css` — not from arbitrary ad-hoc values.
+
+## Configuration
+
+Configure `cssGlobal` to enable breakpoint validation:
+
+```json
+{
+  "kaliber/media-query-convention": [true, {
+    "cssGlobal": "src/cssGlobal"
+  }]
+}
+```
+
+The rule reads `media.js` (or `media.css`) from the configured directory and extracts all defined breakpoint values. Without `cssGlobal`, the rule still enforces `min-width` over `max-width` but skips breakpoint validation.
+
+### Supported formats
+
+**media.js** (rabobank, bol, landal, jumbo):
+```js
+const mediaStyles = {
+  viewportMd: 'screen and (min-width: 48rem)',   // → extracts "48rem"
+  breakpointMd: '768px',                          // → extracts "768px"
+}
+```
+
+**media.css** (klm, eiffel):
+```css
+@custom-media --viewport-md screen and (min-width: 768px);  /* → extracts "768px" */
+```
+
+## What this rule checks
+
+- **Disallows `max-width`** breakpoint queries — use `min-width` instead
+- **Validates breakpoint values** against `cssGlobal/media` (when configured)
+- For the inverse (targeting mobile only), use `@media not screen and (min-width: ...)` or `@media not (min-width: ...)`
+
+## What this rule allows
+
+- **`min-width`** queries with defined breakpoints: `@media screen and (min-width: 48rem)`
+- **Negated `min-width`** queries: `@media not screen and (min-width: 80rem)`
+- **Non-width features**: `prefers-reduced-motion`, `prefers-color-scheme`, `hover`, `pointer`, `orientation`, `display-mode`, `forced-colors`
+- **Print**: `@media print`
+- **Complex queries**: `max-width` combined with `orientation` or `max-height` (legitimate edge cases for landscape mobile)
+
+## Examples
+
+### ✅ Valid
+
+```css
+/* Mobile-first with defined breakpoint */
+.component { @media screen and (min-width: 48rem) { ... } }
+
+/* Mobile-first inverse — also correct */
+.component { @media not screen and (min-width: 80rem) { ... } }
+
+/* Non-width features — always allowed */
+.component { @media (prefers-reduced-motion: no-preference) { ... } }
+```
+
+### ❌ Invalid
+
+```css
+/* max-width — desktop-first, not allowed */
+.component { @media screen and (max-width: 768px) { ... } }
+/* should be: @media not screen and (min-width: 768px) or restructure */
+
+/* Ad-hoc breakpoint — not in media.js */
+.component { @media screen and (min-width: 42rem) { ... } }
+/* should use a defined breakpoint like 48rem */
+```

--- a/stylelint-plugins/rules/media-query-convention/test.js
+++ b/stylelint-plugins/rules/media-query-convention/test.js
@@ -1,0 +1,74 @@
+import { messages, seedBreakpointCache } from './index.js'
+import { test } from '../../machinery/test.js'
+
+// Seed known breakpoints for testing
+seedBreakpointCache(['30rem', '48rem', '64rem', '80rem', '95rem'])
+
+test('media-query-convention', {
+  'media-query-convention': {
+    valid: [
+      {
+        title: 'allow min-width media queries with defined breakpoint',
+        code: '.component { @media screen and (min-width: 48rem) { color: red; } }'
+      },
+      {
+        title: 'allow not screen and (min-width) as mobile-first inverse',
+        code: '.component { @media not screen and (min-width: 80rem) { color: red; } }'
+      },
+      {
+        title: 'allow prefers-reduced-motion',
+        code: '.component { @media (prefers-reduced-motion: no-preference) { transition: transform 0.3s; } }'
+      },
+      {
+        title: 'allow prefers-color-scheme',
+        code: '.component { @media (prefers-color-scheme: dark) { color: white; } }'
+      },
+      {
+        title: 'allow hover media query',
+        code: '.component { @media (hover: hover) { color: blue; } }'
+      },
+      {
+        title: 'allow pointer media query',
+        code: '.component { @media (pointer: fine) { padding: 4px; } }'
+      },
+      {
+        title: 'allow media query without width features',
+        code: '.component { @media print { display: none; } }'
+      },
+      {
+        title: 'allow complex max-width query with orientation (edge case)',
+        code: '.component { @media screen and (max-width: 63.9rem) and (max-height: 60rem) and (orientation: landscape) { color: red; } }'
+      },
+      {
+        title: 'allow all defined breakpoints',
+        code: '.component { @media screen and (min-width: 30rem) { color: red; } @media screen and (min-width: 64rem) { color: blue; } @media screen and (min-width: 95rem) { color: green; } }'
+      },
+      {
+        title: 'allow not (min-width) without screen keyword',
+        code: '.component { @media not (min-width: 48rem) { color: red; } }'
+      },
+    ],
+    invalid: [
+      {
+        title: 'disallow max-width media queries',
+        code: '.component { @media screen and (max-width: 768px) { color: red; } }',
+        warnings: [messages['prefer min-width']('screen and (max-width: 768px)')]
+      },
+      {
+        title: 'disallow simple max-width without screen keyword',
+        code: '.component { @media (max-width: 48rem) { color: red; } }',
+        warnings: [messages['prefer min-width']('(max-width: 48rem)')]
+      },
+      {
+        title: 'disallow unrecognized breakpoint value',
+        code: '.component { @media screen and (min-width: 42rem) { color: red; } }',
+        warnings: [messages['breakpoint not recognized']('42rem', '30rem, 48rem, 64rem, 80rem, 95rem')]
+      },
+      {
+        title: 'disallow ad-hoc pixel breakpoint',
+        code: '.component { @media screen and (min-width: 500px) { color: red; } }',
+        warnings: [messages['breakpoint not recognized']('500px', '30rem, 48rem, 64rem, 80rem, 95rem')]
+      },
+    ],
+  },
+})

--- a/stylelint-plugins/rules/no-hardcoded-colors/index.js
+++ b/stylelint-plugins/rules/no-hardcoded-colors/index.js
@@ -1,0 +1,56 @@
+import { matchesFile } from '../../machinery/filename.js'
+import defineRule from '../../machinery/defineRule.js'
+import docsUrl from '../../machinery/docsUrl.js'
+
+/**
+ * Matches hex colors (#fff, #000000, #RRGGBBAA), rgb/rgba/hsl/hsla function calls,
+ * and named colors used as raw values.
+ *
+ * Intentionally does NOT match inside var() references — those are handled by color-variable-layering.
+ */
+const hardcodedColorPattern = /#[0-9a-fA-F]{3,8}\b|(?:rgba?|hsla?|hwb|lab|lch|oklch|oklab|color)\s*\(/
+
+export const messages = {
+  'no hardcoded colors': value =>
+    `Unexpected hardcoded color value "${truncate(value)}"\n` +
+    `use a CSS custom property from your color system instead (e.g. var(--color), var(--accent-color))`
+}
+
+export default defineRule({
+  ruleName: 'no-hardcoded-colors',
+  meta: {
+    description: 'Disallow hardcoded color values (hex, rgb, hsl, etc.) in component CSS files',
+    url: docsUrl(import.meta.dirname),
+  },
+  ruleInteraction: null,
+  cssRequirements: null,
+  messages,
+  create() {
+    return ({ originalRoot, report }) => {
+      if (isInfraFile(originalRoot)) return
+
+      originalRoot.walkDecls(decl => {
+        const { value, prop } = decl
+
+        // Skip custom property definitions — those are defining tokens, not consuming colors
+        if (prop.startsWith('--')) return
+
+        if (hardcodedColorPattern.test(value)) {
+          report(decl, messages['no hardcoded colors'](value))
+        }
+      })
+    }
+  }
+})
+
+function isInfraFile(root) {
+  return matchesFile(root, filename =>
+    filename.includes('/cssGlobal/') ||
+    filename.includes('/style-contexts') ||
+    /colorScheme.*\.css/.test(filename)
+  )
+}
+
+function truncate(value, maxLength = 60) {
+  return value.length > maxLength ? value.slice(0, maxLength) + '…' : value
+}

--- a/stylelint-plugins/rules/no-hardcoded-colors/readme.md
+++ b/stylelint-plugins/rules/no-hardcoded-colors/readme.md
@@ -1,0 +1,49 @@
+# no-hardcoded-colors
+
+Disallow hardcoded color values (hex, rgb, hsl, etc.) in component CSS files.
+
+## Rationale
+
+Both projects define color tokens in `cssGlobal/color.css` or `cssGlobal/themes/*.css`, then map them through style contexts. When hardcoded color values like `#1a1a1a` or `rgba(0, 0, 0, 0.2)` leak into component CSS, they:
+
+- Bypass the color system entirely
+- Won't adapt to style context changes (light/dark)
+- Create maintenance burden when brand colors change
+
+## What this rule checks
+
+In **component CSS files** (anything outside `cssGlobal/`, `style-contexts`, and `colorScheme` files), this rule disallows:
+
+- Hex colors: `#fff`, `#000000`, `#RRGGBBAA`
+- Color functions: `rgb()`, `rgba()`, `hsl()`, `hsla()`, `hwb()`, `lab()`, `lch()`, `oklch()`, `oklab()`, `color()`
+
+## What this rule allows
+
+- **CSS custom properties**: `var(--color)`, `var(--accent-color)`, etc.
+- **Custom property definitions**: `--my-gradient: linear-gradient(...)` — defining a token is allowed
+- **Infrastructure files**: `cssGlobal/`, `style-contexts.css`, `colorScheme*.css`
+- **Non-color values**: `transparent`, `currentColor`, `inherit`
+
+## Examples
+
+### ✅ Valid
+
+```css
+/* features/buildingBlocks/Button.css */
+.component { color: var(--color); background-color: var(--accent-color); }
+```
+
+```css
+/* cssGlobal/color.css — infrastructure file, allowed */
+:root { --color-blue-500: #0058ff; }
+```
+
+### ❌ Invalid
+
+```css
+/* features/buildingBlocks/Panel.css */
+.component { background-color: #1a1a1a; }
+
+/* features/buildingBlocks/Overlay.css */
+.component { background-color: rgba(0, 0, 0, 0.2); }
+```

--- a/stylelint-plugins/rules/no-hardcoded-colors/test.js
+++ b/stylelint-plugins/rules/no-hardcoded-colors/test.js
@@ -1,0 +1,70 @@
+import { messages } from './index.js'
+import { test } from '../../machinery/test.js'
+
+test('no-hardcoded-colors', {
+  'no-hardcoded-colors': {
+    valid: [
+      {
+        title: 'allow CSS custom properties in component files',
+        filename: 'features/buildingBlocks/Button.css',
+        code: '.component { color: var(--color); background-color: var(--accent-color); }'
+      },
+      {
+        title: 'allow hardcoded colors in cssGlobal files',
+        filename: 'cssGlobal/color.css',
+        code: ':root { --color-blue-500: #0058ff; --color-black: #000; }'
+      },
+      {
+        title: 'allow hardcoded colors in style-contexts files',
+        filename: 'cssGlobal/style-contexts.css',
+        code: '.component { color: #fff; }'
+      },
+      {
+        title: 'allow hardcoded colors in colorScheme files',
+        filename: 'colorScheme/dark.css',
+        code: '.component { background-color: #1a1a1a; }'
+      },
+      {
+        title: 'allow non-color values in component files',
+        filename: 'features/buildingBlocks/Card.css',
+        code: '.component { padding: 16px; width: 100%; opacity: 0.5; }'
+      },
+      {
+        title: 'allow transparent and currentColor keywords',
+        filename: 'features/buildingBlocks/Link.css',
+        code: '.component { background-color: transparent; color: currentColor; border-color: inherit; }'
+      },
+      {
+        title: 'allow custom property definitions in component files',
+        filename: 'features/buildingBlocks/Tile.css',
+        code: '.component { --title-gradient: linear-gradient(to bottom, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.6) 100%); }'
+      },
+    ],
+    invalid: [
+      {
+        title: 'disallow hex colors in component files',
+        filename: 'features/buildingBlocks/Panel.css',
+        code: '.component { background-color: #1a1a1a; }',
+        warnings: [messages['no hardcoded colors']('#1a1a1a')]
+      },
+      {
+        title: 'disallow rgba in component files',
+        filename: 'features/buildingBlocks/Overlay.css',
+        code: '.component { background-color: rgba(0, 0, 0, 0.2); }',
+        warnings: [messages['no hardcoded colors']('rgba(0, 0, 0, 0.2)')]
+      },
+      {
+        title: 'disallow hex shorthand in component files',
+        filename: 'features/pageOnly/Footer.css',
+        code: '.component { color: #fff; }',
+        warnings: [messages['no hardcoded colors']('#fff')]
+      },
+      {
+        title: 'disallow hsl in component files',
+        filename: 'features/buildingBlocks/Card.css',
+        code: '.component { border-color: hsl(210, 100%, 50%); }',
+        warnings: [messages['no hardcoded colors']('hsl(210, 100%, 50%)')]
+      },
+    ],
+  },
+})


### PR DESCRIPTION
I’ve added three new rules to keep our CSS structured, and cleaned up some internal machinery to support them. 

### What's added:

*   **`no-hardcoded-colors`**: Walks PostCSS declarations to block raw hex, rgb, rgba, and hsl values in component files. It permits variable definitions (like gradients) and ignores theme/infra files so token setup still works.
*   **`color-variable-layering`**: Enforces the 3-layer color setup. At lint-time, it parses `style-contexts.css` in the project's `cssGlobal` directory to build an allowlist of context tokens. Any other `--color-*` variables used in component declarations will be flagged.
*   **`media-query-convention`**: Enforces mobile-first design by flagging `max-width` queries (unless combined with complex queries like orientation). If `cssGlobal` is configured, it parses the project's `media.js` (Object literals) or `media.css` (`@custom-media`) to validate query breakpoints and flag typos.

### Internal refactoring:
*   **Split `cssGlobal.js`**: Isolated the media/breakpoint parsing and test-seeding caches into a new `breakpoints.js` utility, leaving only file-reading and path validation in `cssGlobal.js`.
*   **Rule Options**: Updated `callPlugin` in `kaliber.js` to pass `secondaryOptionObject` as `options` so rules can read configuration (like the `cssGlobal` path).
